### PR TITLE
Minor fixes for tab shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 | ------------- | ------------- |
 | Ctrl+G  | Group All  |
 | Ctrl+Shift+G | Ungroup All |
-| Ctrl+T | Group Tab | 
-| Ctrl+Shift+T | Ungroup Tab | 
+| Super+T | Group Tab | 
+| Super+Shift+T | Ungroup Tab | 
 | Alt+A | Broadcast to all terminals |
 | Alt+G | Broadcast to Grouped terminals |
 | Alt+O | Broadcast off |
@@ -79,6 +79,7 @@
 | Ctrl+Alt+X | Rename terminal title |
 | Super+1 | Insert terminal number |
 | Super+0 | Insert padded terminal number |
+| Ctrl+Shift+T | Open new tab |
 
 
 ## Launcher parameters


### PR DESCRIPTION
I've tested below shortcuts on `terminator 1.90`. :white_check_mark:

Also checked from terminator documentation:
- https://terminator-gtk3.readthedocs.io/en/latest/grouping.html#grouping-menu
- https://terminator-gtk3.readthedocs.io/en/latest/gettingstarted.html#using-the-keyboard

![open_new_tab](https://user-images.githubusercontent.com/7355362/119724338-443a7700-be77-11eb-8a08-c67830d3cc12.png)

![group_ungroup_tab](https://user-images.githubusercontent.com/7355362/119724345-456ba400-be77-11eb-88fa-52a7ba010420.png)
